### PR TITLE
Support --profile option

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -5,32 +5,16 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	myS3 "github.com/tsub/s3-edit/cli/s3"
+	"github.com/tsub/s3-edit/config"
 )
 
 // Edit directly a file on S3
-func Edit(path myS3.Path, awsProfile string) {
-	var creds *credentials.Credentials
-	if awsProfile != "" {
-		currentUser, err := user.Current()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		creds = credentials.NewSharedCredentials(fmt.Sprintf("%s/.aws/credentials", currentUser.HomeDir), awsProfile)
-	}
-	sess := session.Must(session.NewSession(&aws.Config{
-		Credentials: creds,
-	}))
-	svc := s3.New(sess)
+func Edit(path myS3.Path, params *config.AWSParams) {
+	svc := s3.New(params.Session)
 
 	body := myS3.GetObject(svc, path)
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tsub/s3-edit/cli"
 	"github.com/tsub/s3-edit/cli/s3"
+	"github.com/tsub/s3-edit/config"
 )
 
 var editCmd = &cobra.Command{
@@ -21,7 +22,13 @@ var editCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cli.Edit(path, awsProfile)
+		params, err := config.NewAWSParams(awsProfile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		cli.Edit(path, params)
 	},
 }
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -21,7 +21,7 @@ var editCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cli.Edit(path)
+		cli.Edit(path, awsProfile)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,9 @@ func Execute() {
 }
 
 var isShowVersion bool
+var awsProfile string
 
 func init() {
 	RootCmd.Flags().BoolVarP(&isShowVersion, "version", "v", false, "print the version of s3-edit")
+	RootCmd.PersistentFlags().StringVarP(&awsProfile, "profile", "", "", "Use a specific profile from your credential file")
 }

--- a/config/aws_config.go
+++ b/config/aws_config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"fmt"
+	"os/user"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// AWSParams saves config to to create an aws service clients
+type AWSParams struct {
+	Session *session.Session
+}
+
+// NewAWSParams creates a new AWSParams object
+func NewAWSParams(awsProfile string) (*AWSParams, error) {
+	var creds *credentials.Credentials
+
+	if awsProfile != "" {
+		currentUser, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+
+		creds = credentials.NewSharedCredentials(fmt.Sprintf("%s/.aws/credentials", currentUser.HomeDir), awsProfile)
+	}
+
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: creds,
+	}))
+
+	return &AWSParams{
+		Session: sess,
+	}, nil
+}


### PR DESCRIPTION
## Why?

Closes https://github.com/tsub/s3-edit/issues/9

## How?

* Add `--profile` global option

### Usage

```
$ s3-edit edit --profile myprofile s3://mybucket/myfile
```

Same as below.

```
$ AWS_PROFILE=myprofile s3-edit edit s3://mybucket/myfile
```