### PR TITLE
Set default editor

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -60,5 +60,9 @@ func editFile(path string) string {
 }
 
 func getDefaultEditor() string {
-	return os.Getenv("EDITOR")
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		return "vi"
+	}
+	return editor
 }


### PR DESCRIPTION
s3-edit tries to exec the target file on s3 when EDITOR is not set. It's not good 🤕 
```
/tmp/README.md: line 1: qwerty: command not found
/tmp/README.md: line 2: qawetp: command not found
```

so, set vi as a default EDITOR.