### PR TITLE
Fix degradation in 3130bfe

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,5 +35,5 @@ var awsProfile string
 
 func init() {
 	RootCmd.Flags().BoolVarP(&isShowVersion, "version", "v", false, "print the version of s3-edit")
-	RootCmd.PersistentFlags().StringVarP(&awsProfile, "profile", "", "default", "Use a specific profile from your credential file")
+	RootCmd.PersistentFlags().StringVarP(&awsProfile, "profile", "", "", "Use a specific profile from your credential file")
 }


### PR DESCRIPTION
## Why?

`$AWS_PROFILE` is not worked.

```
$ AWS_PROFILE=myprofile aws configure get region
ap-northeast-1
$ AWS_PROFILE=myprofile s3-edit edit s3://tsub-sandbox/test.txt
MissingRegion: could not find region configuration

$ AWS_PROFILE=myprofile AWS_REGION=ap-northeast-1 s3-edit edit s3://tsub-sandbox/test.txt
NoCredentialProviders: no valid providers in chain. Deprecated.
        For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

## How?

Do not specify `default` profile when `--profile` is not set.

```
$ AWS_PROFILE=myprofile go run main.go edit s3://tsub-sandbox/test.txt # is working

$ AWS_PROFILE=myprofile aws configure get region
ap-northeast-1
```