### PR TITLE
Inherit Content-Type from existing object

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -16,13 +16,14 @@ import (
 func Edit(path myS3.Path, params *config.AWSParams) {
 	svc := s3.New(params.Session)
 
-	body := myS3.GetObject(svc, path)
+	object := myS3.GetObject(svc, path)
 
-	tempfilePath := createTempfile(path, body)
+	tempfilePath := createTempfile(path, object.Body)
 	defer os.Remove(tempfilePath)
 
 	editedBody := editFile(tempfilePath)
-	myS3.PutObject(svc, path, editedBody)
+	object.Body = []byte(editedBody)
+	myS3.PutObject(svc, path, object)
 }
 
 func createTempfile(path myS3.Path, body []byte) (tempfilePath string) {


### PR DESCRIPTION
## Why?

fixed https://github.com/tsub/s3-edit/issues/12

## How?

* Inherit Content-Type from existing object

## How to check operation

### before

1. Change Content-Type from `binary/octet-stream`

    ![image](https://user-images.githubusercontent.com/10208211/44628255-2b739e80-a977-11e8-84bc-23f35894e823.png)

1. Open and edit that file in s3-edit
    
    ```
    $ s3-edit edit s3://tsub-sandbox/test.txt
    ```

1. Confirm Content-Type

    ![image](https://user-images.githubusercontent.com/10208211/44628279-8a391800-a977-11e8-95a6-3e7e4c6c747f.png)

### after

1. Change Content-Type from `binary/octet-stream`

    ![image](https://user-images.githubusercontent.com/10208211/44628255-2b739e80-a977-11e8-84bc-23f35894e823.png)

1. Open and edit that file in s3-edit
    
    ```
    $ go run main.go edit s3://tsub-sandbox/test.txt
    ```

1. Confirm Content-Type

    ![image](https://user-images.githubusercontent.com/10208211/44628255-2b739e80-a977-11e8-84bc-23f35894e823.png)