### PR TITLE
feat: Support assuming a role with MFA token

### DIFF
--- a/config/aws_config.go
+++ b/config/aws_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -12,8 +13,9 @@ type AWSParams struct {
 // NewAWSParams creates a new AWSParams object
 func NewAWSParams(awsProfile string) (*AWSParams, error) {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		Profile:           awsProfile,
-		SharedConfigState: session.SharedConfigEnable,
+		Profile:                 awsProfile,
+		SharedConfigState:       session.SharedConfigEnable,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 	}))
 
 	return &AWSParams{


### PR DESCRIPTION
Hi. I got an error wiht MFA due to not supported it.

```
panic: AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.
```

This PR gives AssumeRoleTokenProvider to the session.
https://docs.aws.amazon.com/sdk-for-go/api/aws/session/

looks this:
```
$ go run main.go --profile hoge edit s3://path/to/file
Assume Role MFA token code:
```